### PR TITLE
Define frontend API environment variables

### DIFF
--- a/rose-hotel-front-master/.env
+++ b/rose-hotel-front-master/.env
@@ -1,1 +1,11 @@
-VITE_API_URL=http://localhost:3000
+VITE_API_BASE_URL=http://localhost:3000
+VITE_RESTAURANTS_ENDPOINT=/resturants
+VITE_MENU_ITEMS_ENDPOINT=/menu/items
+VITE_MENU_CATEGORIES_ENDPOINT=/menu/categories
+VITE_MENU_ITEMS_BY_CATEGORY_ENDPOINT=/menu/items/category
+VITE_RESERVATIONS_AVAILABLE_ENDPOINT=/reservations/available
+VITE_RESERVATIONS_CREATE_ENDPOINT=/reservations/create
+VITE_TABLES_ENDPOINT=/tables
+VITE_CART_ADD_ENDPOINT_MULTIPLE=/cart/add-multiple
+VITE_RESERVATIONS_SET_ORDER=/orders/place
+VITE_HOME_IMAGE=http://localhost:3000/images/home.jpg


### PR DESCRIPTION
## Summary
- declare Vite environment variables for API base URL and all endpoint paths in the frontend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint: not found; npm ci 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68adde328e68832aafb787016580b066