### PR TITLE
fix: send english datetime for table availability

### DIFF
--- a/rose-hotel-front-master/src/Components/tableReserve.tsx
+++ b/rose-hotel-front-master/src/Components/tableReserve.tsx
@@ -10,7 +10,7 @@ import { Link, useNavigate, useLocation } from "react-router-dom";
 import { toast } from "react-toastify";
 import reserveImage from "../assets/images/home.png";
 import icon from "../assets/images/logo.png";
-import { toFarsiNumber } from "../Utils/setNumbersToPersian";
+import { toFarsiNumber, toEnglishNumber } from "../Utils/setNumbersToPersian";
 
 interface ITable {
 	name: string;
@@ -99,10 +99,12 @@ function Reserve() {
 			console.log("Original date:", date.toISOString());
 			console.log("formattedDate", formattedDate);
 			// Convert date to Persian (Shamsi) for logging or display
-			const persianDate = moment(date).format("jYYYY/jMM/jDD");
-			const hourString = hour ? hour.format("HH:mm") : "";
+                        const persianDate = moment(date).format("jYYYY/jMM/jDD");
+                        const hourString = hour
+                                ? toEnglishNumber(hour.format("HH:mm"))
+                                : "";
                         const reservationData = {
-                                date: persianDate,
+                                date: formattedDate,
                                 hour: hourString,
                                 duration,
                                 people: guests,

--- a/rose-hotel-front-master/src/Utils/setNumbersToPersian.tsx
+++ b/rose-hotel-front-master/src/Utils/setNumbersToPersian.tsx
@@ -1,2 +1,5 @@
 export const toFarsiNumber = (n:any) =>
-	n.toString().replace(/\d/g, (d:number) => "۰۱۲۳۴۵۶۷۸۹"[d]);
+        n.toString().replace(/\d/g, (d:number) => "۰۱۲۳۴۵۶۷۸۹"[d]);
+
+export const toEnglishNumber = (s: string) =>
+        s.replace(/[۰-۹]/g, (d) => "0123456789"["۰۱۲۳۴۵۶۷۸۹".indexOf(d)]);


### PR DESCRIPTION
## Summary
- ensure reservation API uses Gregorian date and English digits
- expose toEnglishNumber helper for converting Persian numerals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'react' or its types)*

------
https://chatgpt.com/codex/tasks/task_b_68ade630c328832abae81b1c8dd0b819